### PR TITLE
Fix usage example for placeholder.text

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ```hbs
 {{#content-placeholders as |placeholder|}}
   {{placeholder.heading img=true}}
-  {{placeholder.text lines="3"}}
+  {{placeholder.text lines=3}}
 {{/content-placeholders}}
 ```
 


### PR DESCRIPTION
`lines` expects an integer, not a string.